### PR TITLE
Add dev server and Jest setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Caremate
+
+This project contains static files for a simple web prototype. A small Node-based development setup is included so you can run a local server and add future tests.
+
+## Prerequisites
+- [Node.js](https://nodejs.org/) (version 14 or higher recommended)
+
+## Installing dependencies
+Run the following command in the project directory to install development dependencies:
+
+```bash
+npm install
+```
+
+## Running the development server
+You can launch a local server that reloads when files change using:
+
+```bash
+npm start
+```
+
+This uses [live-server](https://github.com/tapio/live-server) to serve `index.html` on a local port and automatically open it in your browser.
+
+## Running tests
+A placeholder test suite is set up with [Jest](https://jestjs.io/). To run the tests:
+
+```bash
+npm test
+```
+
+Currently there is a simple sample test in `test/sample.test.js` which can be expanded as the project grows.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "caremate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "jest",
+    "start": "live-server --open=./index.html"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "live-server": "^1.2.2"
+  }
+}

--- a/test/sample.test.js
+++ b/test/sample.test.js
@@ -1,0 +1,5 @@
+const sum = (a, b) => a + b;
+
+test('adds numbers', () => {
+  expect(sum(1, 2)).toBe(3);
+});


### PR DESCRIPTION
## Summary
- initialize npm project and install `live-server` and `jest`
- add npm scripts for running the dev server and tests
- provide sample Jest test
- document setup and usage in `README.md`
- ignore `node_modules` and lockfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa0c9980483339ee4754a3818facf