### PR TITLE
Update Stripe key config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Define this variable before including the script. An easy way is to insert the k
 <script src="payment.js"></script>
 ```
 
-To keep the key out of source control you can generate a config file at build time:
+To keep the key out of source control you can generate a config file at build time from an environment variable:
 
 ```bash
+export STRIPE_PUBLIC_KEY=pk_test_your_key_here
 echo "window.STRIPE_PUBLIC_KEY='${STRIPE_PUBLIC_KEY}'" > stripe-config.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,23 @@ npm run lint
 npm run format
 ```
 
-### Environment variables
+### Stripe configuration
 
-Stripe requires a public API key for the checkout flow. Set the variable before running the server:
+`payment.js` looks for the Stripe public key on `window.STRIPE_PUBLIC_KEY`.
+Define this variable before including the script. An easy way is to insert the key directly in your HTML:
 
-```bash
-export STRIPE_PUBLIC_KEY=pk_test_your_key_here
+```html
+<script>window.STRIPE_PUBLIC_KEY = 'pk_test_your_key_here';</script>
+<script src="payment.js"></script>
 ```
 
-Update `payment.js` to read this value or replace the placeholder key in the file.
+To keep the key out of source control you can generate a config file at build time:
+
+```bash
+echo "window.STRIPE_PUBLIC_KEY='${STRIPE_PUBLIC_KEY}'" > stripe-config.js
+```
+
+Include `stripe-config.js` before `payment.js` in `index.html`.
 
 ## Folder Structure
 

--- a/payment.js
+++ b/payment.js
@@ -10,13 +10,16 @@ let stripe;
 
 // Wait for DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
-    // Initialize Stripe if the API key is available
-    const stripePublicKey = 'pk_test_placeholder'; // Replace with actual public key in production
-    
-    if (stripePublicKey) {
-        stripe = Stripe(stripePublicKey);
-        initPaymentForms();
+    // Initialize Stripe using a key defined on the page
+    const stripePublicKey = window.STRIPE_PUBLIC_KEY;
+
+    if (!stripePublicKey) {
+        console.error('Stripe public key missing. Set window.STRIPE_PUBLIC_KEY before loading payment.js');
+        return;
     }
+
+    stripe = Stripe(stripePublicKey);
+    initPaymentForms();
     
     // Initialize payment-related UI elements
     initPricingSelectors();


### PR DESCRIPTION
## Summary
- load Stripe key from `window.STRIPE_PUBLIC_KEY`
- document how to inject this key in the README

## Testing
- `npm run lint`
- `npm run format` *(then reverted unrelated formatting)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9e0fdc88333a99a49036582e9b4